### PR TITLE
Remove extraneous Windows path for jar

### DIFF
--- a/blockproc/java/Makefile
+++ b/blockproc/java/Makefile
@@ -8,7 +8,7 @@ include ostools.mk
 
 default:
 	$(JC) $(FLAGS) net/sourceforge/ltfat/*.java net/sourceforge/ltfat/thirdparty/*.java
-	C:\Program Files\Java\jdk-15.0.2\bin\jar cf blockproc.jar net/sourceforge/ltfat/*.class net/sourceforge/ltfat/thirdparty/*.class
+	jar cf blockproc.jar net/sourceforge/ltfat/*.class net/sourceforge/ltfat/thirdparty/*.class
 
 clean: classclean
 	$(RM)  *.jar


### PR DESCRIPTION
This prevents the package to build on Linux-based systems, like Debian. This also brings back the code that worked in version 2.5.0 of ltfat.