### PR TITLE
Make function name coincide with file name

### DIFF
--- a/testing/test_dgt_fb_alg.m
+++ b/testing/test_dgt_fb_alg.m
@@ -1,4 +1,4 @@
-function test_failed=test_dgt_fb
+function test_failed=test_dgt_fb_alg
 %TEST_DGT_FB  Test the filter bank algorithms in DGT
 %
 %  This script runs a throrough test of the DGT routine,


### PR DESCRIPTION
Otherwise, we get this warning message:

warning: function name 'test_dgt_fb' does not agree with function filename '/<<path-to>>/test_dgt_fb_alg.m'