### PR TITLE
Fix bugs

### DIFF
--- a/auditory/gammatonefir.m
+++ b/auditory/gammatonefir.m
@@ -85,7 +85,7 @@ nchannels = length(fc);
 
 % ourbeta is used in order not to mask the beta function.
 
-ourbeta = betamul*audfiltbw(fc);
+ourbeta = betamul.*audfiltbw(fc);
 
 if isempty(n)
   % Calculate a good value for n


### PR DESCRIPTION
According to the documentation, "The bandwidth beta of each filter is determined as betamul times audfiltbw of the corresponding filter," and "each entry of fc is considered as one center frequency." The keywords "each" and "corresponding" indicate element-wise operations. When fc is a vector (e.g., [1×15]), the original matrix multiplication * causes dimension mismatch errors. Changing to element-wise multiplication .* correctly computes beta(i) = betamul(i) * audfiltbw(fc(i)) for each filter channel, as the documentation intends.